### PR TITLE
add commands to disable and enable the file editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ Removes all security rules.
 wp secure flush
 ```
 
+### wp secure disable-file-editor
+
+Disables the Wordpress file editor. It could be used to edit arbitrary files using the web interface.
+This makes it easier for attackers to change files on the server using a web browser.
+We suggest to disable the file editor off.
+
+```
+wp secure disable-file-editor
+```
+
+### wp secure enable-file-editor
+
+Enables the Wordpress file editor. See wp secure disable-file-editor.
+
+```
+wp secure enable-file-editor
+```
+
 ## Global options
 
 ### Remove single security rule

--- a/src/SecureCommand.php
+++ b/src/SecureCommand.php
@@ -301,4 +301,22 @@ class SecureCommand extends WP_CLI_Command {
     public function integrityscan($args, $assoc_args) : void {
         WP_CLI::runcommand('core verify-checksums');
     }
+
+    /**
+     * Disable the file editor in Wordpress.
+     *
+     * @return void
+     */
+    public function disable_file_editor() : void {
+        WP_CLI::runcommand('config set DISALLOW_FILE_EDIT true');
+    }
+
+    /**
+     * Enable the file editor in Wordpress.
+     *
+     * @return void
+     */
+    public function allow_file_editor() : void {
+        WP_CLI::runcommand('config set DISALLOW_FILE_EDIT false');
+    }
 }


### PR DESCRIPTION
We did not know how to install the branch of the wp-cli-secure-command with the wp cli tool.
We tested by running `wp config set DISALLOW_FILE_EDIT false` and `wp config set DISALLOW_FILE_EDIT true`.

Verification was done by running `cat wp-config.php | grep DISALLOW_FILE_EDIT`.